### PR TITLE
layout.conf: Do not sign manifests

### DIFF
--- a/metadata/layout.conf
+++ b/metadata/layout.conf
@@ -5,4 +5,4 @@ eapis-banned = 0 1 2 3 4
 
 update-changelog = false
 thin-manifests = true
-sign-manifests = true
+sign-manifests = false


### PR DESCRIPTION
It doesn't make sense to sign manifests in a collaborative user overlay.
