### PR TITLE
Make all 'date' calls from within of 'pkg_setup'

### DIFF
--- a/dev-go/goxc/goxc-0.18.1-r1.ebuild
+++ b/dev-go/goxc/goxc-0.18.1-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 
 GOLANG_PKG_IMPORTPATH="github.com/laher"
 GOLANG_PKG_ARCHIVEPREFIX="v"
-GOLANG_PKG_LDFLAGS="-X main.VERSION=${PV} -X main.BUILD_DATE=$( date -u '+%m-%d-%Y' )"
+GOLANG_PKG_LDFLAGS="-X main.VERSION=${PV}"
 GOLANG_PKG_HAVE_TEST=1
 
 GOLANG_PKG_DEPENDENCIES=(
@@ -21,3 +21,7 @@ DESCRIPTION="Goxc is a build tool for GoLange, with a focus on cross-compiling a
 LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="amd64 x86 arm"
+
+pkg_setup() {
+	GOLANG_PKG_LDFLAGS+=" -X main.BUILD_DATE=$( date -u '+%m-%d-%Y' )"
+}

--- a/net-p2p/syncthing/syncthing-0.14.39-r50.ebuild
+++ b/net-p2p/syncthing/syncthing-0.14.39-r50.ebuild
@@ -7,7 +7,7 @@ GOLANG_PKG_IMPORTPATH="github.com/${PN}"
 GOLANG_PKG_ARCHIVEPREFIX="v"
 GOLANG_PKG_BUILDPATH="/cmd/${PN}"
 GOLANG_PKG_TAGS="noupgrade"
-GOLANG_PKG_LDFLAGS="-w -X main.Version=v${PV} -X main.BuildUser=portage -X main.BuildHost=gentoo -X main.BuildStamp=$( date +%s )"
+GOLANG_PKG_LDFLAGS="-w -X main.Version=v${PV} -X main.BuildUser=portage -X main.BuildHost=gentoo"
 
 inherit user systemd golang-single
 
@@ -33,6 +33,7 @@ SYNCTHING_HOME="/var/lib/${PN}"
 
 pkg_setup() {
 	enewuser ${PN} -1 -1 "${SYNCTHING_HOME}"
+	GOLANG_PKG_LDFLAGS+=" -X main.BuildStamp=$( date +%s )"
 }
 
 src_compile() {

--- a/sys-fs/gocryptfs/gocryptfs-1.2.ebuild
+++ b/sys-fs/gocryptfs/gocryptfs-1.2.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 
 GOLANG_PKG_IMPORTPATH="github.com/rfjakob"
 GOLANG_PKG_ARCHIVEPREFIX="v"
-GOLANG_PKG_LDFLAGS="-X main.GitVersion=${PV} -X main.GitVersionFuse=0ad840c -X main.BuildTime=$( date +%s )"
+GOLANG_PKG_LDFLAGS="-X main.GitVersion=${PV} -X main.GitVersionFuse=0ad840c"
 GOLANG_PKG_HAVE_TEST=1
 GOLANG_PKG_USE_CGO=1
 
@@ -28,6 +28,10 @@ IUSE="ssl"
 
 RDEPEND="sys-fs/fuse
 	ssl? ( dev-libs/openssl:0 )"
+
+pkg_setup() {
+	GOLANG_PKG_LDFLAGS+=" -X main.BuildTime=$( date +%s )"
+}
 
 src_compile() {
 	use ssl || GOLANG_PKG_TAGS="without_openssl"

--- a/www-apps/gogs/gogs-0.9.141.ebuild
+++ b/www-apps/gogs/gogs-0.9.141.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 
 GOLANG_PKG_IMPORTPATH="github.com/gogits"
 GOLANG_PKG_ARCHIVEPREFIX="v"
-GOLANG_PKG_LDFLAGS="-X github.com/gogits/gogs/modules/setting.BuildTime=$(date -u '+%Y-%m-%d') -X github.com/gogits/gogs/modules/setting.BuildGitHash=0ea0c5e"
+GOLANG_PKG_LDFLAGS="-X github.com/gogits/gogs/modules/setting.BuildGitHash=0ea0c5e"
 GOLANG_PKG_USE_CGO=1
 GOLANG_PKG_HAVE_TEST=1
 
@@ -129,6 +129,7 @@ APP_DIR="/usr/share/${PN}"
 pkg_setup() {
 	enewgroup ${USER_NAME}
 	enewuser ${USER_NAME} -1 /bin/bash "${USER_DIR}" ${USER_NAME}
+	GOLANG_PKG_LDFLAGS+=" -X github.com/gogits/gogs/modules/setting.BuildTime=$(date -u '+%Y-%m-%d')"
 }
 
 src_prepare() {

--- a/www-apps/hugo/hugo-0.18.1.ebuild
+++ b/www-apps/hugo/hugo-0.18.1.ebuild
@@ -5,7 +5,6 @@ EAPI=6
 
 GOLANG_PKG_IMPORTPATH="github.com/spf13"
 GOLANG_PKG_ARCHIVEPREFIX="v"
-GOLANG_PKG_LDFLAGS="-X ${GOLANG_PKG_IMPORTPATH}/${PN}/hugolib.BuildDate=$( date +%FT%T%z )"
 GOLANG_PKG_HAVE_TEST=1
 
 GOLANG_PKG_DEPENDENCIES=(
@@ -64,6 +63,10 @@ KEYWORDS="amd64 x86 arm"
 IUSE+=" doc pygments"
 
 RDEPEND="pygments? ( dev-python/pygments )"
+
+pkg_setup() {
+	GOLANG_PKG_LDFLAGS=" -X ${GOLANG_PKG_IMPORTPATH}/${PN}/hugolib.BuildDate=$( date +%FT%T%z )"
+}
 
 src_prepare() {
 	golang-single_src_prepare

--- a/www-apps/hugo/hugo-0.20.ebuild
+++ b/www-apps/hugo/hugo-0.20.ebuild
@@ -5,7 +5,6 @@ EAPI=6
 
 GOLANG_PKG_IMPORTPATH="github.com/spf13"
 GOLANG_PKG_ARCHIVEPREFIX="v"
-GOLANG_PKG_LDFLAGS="-X ${GOLANG_PKG_IMPORTPATH}/${PN}/hugolib.BuildDate=$( date +%FT%T%z )"
 GOLANG_PKG_HAVE_TEST=1
 
 GOLANG_PKG_DEPENDENCIES=(
@@ -67,6 +66,10 @@ KEYWORDS="amd64 x86 arm"
 IUSE+=" doc pygments"
 
 RDEPEND="pygments? ( dev-python/pygments )"
+
+pkg_setup() {
+	GOLANG_PKG_LDFLAGS=" -X ${GOLANG_PKG_IMPORTPATH}/${PN}/hugolib.BuildDate=$( date +%FT%T%z )"
+}
 
 src_prepare() {
 	golang-single_src_prepare

--- a/www-servers/caddy/caddy-0.9.5.ebuild
+++ b/www-servers/caddy/caddy-0.9.5.ebuild
@@ -9,7 +9,7 @@ GOLANG_PKG_IMPORTPATH="github.com/mholt"
 GOLANG_PKG_ARCHIVEPREFIX="v"
 GOLANG_PKG_BUILDPATH="/${PN}"
 PKG="${GOLANG_PKG_IMPORTPATH}/${PN}/${PN}/${PN}main"
-GOLANG_PKG_LDFLAGS="-X ${PKG}.appVersion=v${PV} -X ${PKG}.gitTag=v${PV} -X ${PKG}.gitCommit=c885edd -X \"${PKG}.buildDate=$( date -u +"%a %b %d %H:%M:%S %Z %Y" )\""
+GOLANG_PKG_LDFLAGS="-X ${PKG}.appVersion=v${PV} -X ${PKG}.gitTag=v${PV} -X ${PKG}.gitCommit=c885edd"
 GOLANG_PKG_HAVE_TEST=1
 
 GOLANG_PKG_DEPENDENCIES=(
@@ -58,6 +58,7 @@ USER_DIR="/var/lib/${USER_NAME}"
 pkg_setup() {
 	enewgroup ${USER_NAME}
 	enewuser ${USER_NAME} -1 /bin/bash "${USER_DIR}" ${USER_NAME}
+	GOLANG_PKG_LDFLAGS+=" -X \"${PKG}.buildDate=$( date -u +"%a %b %d %H:%M:%S %Z %Y" )\""
 }
 
 src_prepare() {


### PR DESCRIPTION
```text
Since EAPI 6 requires that no external command is called if an ebuild is
merely sourced into an interpreter, we cannot use '$(date +FMT)' in global
variables anymore. Putting them into 'pkg_setup' instead seems like
a reasonable solution.
```

Aimed to fix #66. 