### PR TITLE
Get an updated version of .travis.yml from mrueg/repoman-travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,29 @@
+# Borrowed from https://github.com/mrueg/repoman-travis
 language: python
 python:
     - pypy
 env:
-    - PORTAGE_VER="2.2.28"
+    - PORTAGE_VER="2.3.13"
+before_install:
+    - sudo apt-get -qq update
+    - pip install lxml
 before_script:
-    - mkdir travis-overlay
+    - sudo chmod a+rwX /etc/passwd /etc/group /etc /usr
+    - mkdir -p travis-overlay /etc/portage /usr/portage/distfiles
     - mv !(travis-overlay) travis-overlay/
     - mv .git travis-overlay/
     - wget "https://raw.githubusercontent.com/mrueg/repoman-travis/master/.travis.yml" -O .travis.yml.upstream
     - wget "https://raw.githubusercontent.com/mrueg/repoman-travis/master/spinner.sh"
-    - wget "https://github.com/gentoo/portage/archive/v${PORTAGE_VER}.tar.gz" -O portage-${PORTAGE_VER}.tar.gz
-    - wget "https://github.com/gentoo-mirror/gentoo/archive/master.tar.gz" -O portage-tree.tar.gz
-    - sudo chmod a+rwX /etc/passwd /etc/group /etc /usr spinner.sh
+    - wget -qO - "https://github.com/gentoo/portage/archive/portage-${PORTAGE_VER}.tar.gz" | tar xz
+    - wget -qO - "https://github.com/gentoo-mirror/gentoo/archive/master.tar.gz" | tar xz -C /usr/portage --strip-components=1
     - chmod a+rwx spinner.sh
     - echo "portage:x:250:250:portage:/var/tmp/portage:/bin/false" >> /etc/passwd
     - echo "portage::250:portage,travis" >> /etc/group
-    - mkdir -p /etc/portage /usr/portage/distfiles
     - wget "https://www.gentoo.org/dtd/metadata.dtd" -O /usr/portage/distfiles/metadata.dtd
-    - tar xzf portage-${PORTAGE_VER}.tar.gz
-    - tar xzf portage-tree.tar.gz -C /usr/portage --strip-components=1
-    - cp portage-${PORTAGE_VER}/cnf/repos.conf /etc/portage/
-    - ln -s /usr/portage/profiles/base/ /etc/portage/make.profile
+    - ln -s portage-portage-${PORTAGE_VER}/cnf/repos.conf /etc/portage/repos.conf
+    - ln -s /usr/portage/profiles/default/linux/amd64/13.0 /etc/portage/make.profile
     - SIZE=$(stat -c %s .travis.yml.upstream)
     - if ! cmp -n $SIZE -s .travis.yml .travis.yml.upstream; then echo -e "\e[31m !!! .travis.yml outdated! Update available https://github.com/mrueg/repoman-travis \e[0m" > /tmp/update ; fi
     - cd travis-overlay
 script:
-    - ./../spinner.sh "python ../portage-${PORTAGE_VER}/bin/repoman -xv -d full"
+    - ./../spinner.sh "python ../portage-portage-${PORTAGE_VER}/repoman/bin/repoman full -d"


### PR DESCRIPTION
```text
This fixes the CI build which got accidentally broken due to the absence
of xmllint.
```

Despite Travis says that this PR's build has failed, it was caused by the ebuilds themselves (since they call external `data +FMT` which is now forbidden by EAPI), not the updated `.travis.yml` configuration.