### PR TITLE
[app-shells/fzf] Remove arm support

### DIFF
--- a/app-shells/fzf/fzf-0.17.1.ebuild
+++ b/app-shells/fzf/fzf-0.17.1.ebuild
@@ -21,7 +21,7 @@ DESCRIPTION="A general-purpose command-line fuzzy finder"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="amd64 arm x86"
+KEYWORDS="amd64 x86"
 IUSE="tmux neovim vim bash-completion zsh-completion fish-completion"
 
 RDEPEND="bash-completion? ( app-shells/bash )


### PR DESCRIPTION
I'm removing `arm` support for FZF just because `fish` can't be installed on it. In reality though, I'm not sure if `fzf` could be installed on arm systems or not. What do you think?

If it should be installable on `arm`, should we just remove this runtime dependency?