### PR TITLE
fix: Invalid atom dev-lang/go:stable

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -14,7 +14,7 @@
 # Toffanin Mauro <toffanin.mauro@gmail.com> (2019-10-01)
 =app-eselect/eselect-go-9999
 =dev-lang/go-bootstrap-1.8
-dev-lang/go:stable
+# dev-lang/go:stable
 
 # Gantenbein Reto <reto.gantenbein@linuxmonk.ch> (2019-09-25)
 # Depends on dev-go/go-protobuf which is hard-masked upstream and likely


### PR DESCRIPTION
fix: Invalid atom in /var/db/repos/go-overlay/profiles/package.mask: Slot deps are not allowed in EAPI 0: 'dev-lang/go:stable'